### PR TITLE
Downgrade postcss-focus-visible

### DIFF
--- a/templates/nuxt/base/package.json
+++ b/templates/nuxt/base/package.json
@@ -24,7 +24,7 @@
     "@nuxtjs/sitemap": "^2.4.0",
     "nuxt": "^2.15.0",
     "nuxt-typed-vuex": "^0.2.0",
-    "postcss-focus-visible": "^6.0.3",
+    "postcss-focus-visible": "^5.0.0",
     "core-js": "^3.6.5",
     "focus-visible": "^5.2.0",
     "lazysizes": "^5.3.2",


### PR DESCRIPTION
Newer version requires postcss8 which requires newer nuxt version which throws a weird error. Downgrade works fine.